### PR TITLE
Fix Charm category ID in _metadata.py

### DIFF
--- a/cs2inspect/_metadata.py
+++ b/cs2inspect/_metadata.py
@@ -244,7 +244,7 @@ CATEGORY_IDS = {
     1209: "Sticker",
     1349: "Graffiti",
     4609: "Patch",
-    62: "Charm"
+    1355: "Charm"
 }
 
 


### PR DESCRIPTION
This pull request makes a small fix to the mapping of item types in the `build_full_name` function. The key for "Charm" has been updated from 62 to 1355 to ensure correct identification. #12