### PR TITLE
Add paintseed for Charm

### DIFF
--- a/cs2inspect/_util_parse.py
+++ b/cs2inspect/_util_parse.py
@@ -335,6 +335,7 @@ def build_full_name(result: dict[str, Any], schema: ItemSchema) -> None:
             result["stickers"] = []
         elif weapon == "Charm" and result.get("keychains"):
             charm = result["keychains"][0]
+            result["paintseed"] = charm.get("pattern",0)
             result["full_item_name"] = charm.get("name", weapon)
             result["item_name"] = charm.get("name")
             result["collection_name"] = charm.get("collection_name")


### PR DESCRIPTION
This pull request makes a small update to how charm items are processed in the `build_full_name` function. Now, when a charm is present, its `pattern` value (or 0 if missing) is added to the result as `paintseed`. #12