### PR TITLE
Add paintindex to charm processing logic

### DIFF
--- a/cs2inspect/_util_parse.py
+++ b/cs2inspect/_util_parse.py
@@ -425,6 +425,7 @@ def build_full_name(result: dict[str, Any], schema: ItemSchema) -> None:
         elif weapon == "Charm" and result.get("keychains"):
             charm = result["keychains"][0]
             result["paintseed"] = charm.get("pattern", 0)
+            result["paintindex"] = charm.get("sticker_id",0)
             result["full_item_name"] = charm.get("name", weapon)
             result["item_name"] = charm.get("name")
             result["collection_name"] = charm.get("collection_name")


### PR DESCRIPTION
This pull request makes a small update to the logic for handling "Charm" weapons in the `build_full_name` function. The change ensures that the `paintindex` field is set for charms, using the `sticker_id` value from the keychain if available. #15 